### PR TITLE
We need to bind to the mcast group address in the call to socat to on…

### DIFF
--- a/bash-init.sh
+++ b/bash-init.sh
@@ -8,7 +8,7 @@ function to_bus () {
 export to_bus
 
 function from_bus () {
-    socat "UDP4-RECV:12737,reuseaddr,ip-add-membership=239.111.42.$1:0.0.0.0" STDOUT
+    socat "UDP4-RECV:12737,bind=239.111.42.$1,reuseaddr,ip-add-membership=239.111.42.$1:0.0.0.0" STDOUT
 }
 export from_bus
 

--- a/tests/test_porla.bats
+++ b/tests/test_porla.bats
@@ -37,3 +37,18 @@ teardown() {
     assert cmp --silent "$TMP_DIR"/test.txt "$TMP_DIR"/out.txt
 
 }
+
+@test "Single writer/listener|writer/listener chain on bus" {
+    bats_require_minimum_version 1.5.0
+
+    docker run -d -v "$TMP_DIR":/recordings --network=host porla "from_bus 37 | record /recordings/out.txt"
+
+    docker run -d -v "$TMP_DIR":/recordings --network=host porla "from_bus 36 | to_bus 37"
+
+    docker run -v "$TMP_DIR":/recordings --network=host porla "cat /recordings/test.txt | to_bus 36"
+
+    assert_exists "$TMP_DIR"/out.txt
+
+    assert cmp --silent "$TMP_DIR"/test.txt "$TMP_DIR"/out.txt
+
+}


### PR DESCRIPTION
…ly get packets for the specific group, otherwise we get packets for all groups on the specific port.