### PR TITLE
Fixing issue with SIGTERM not being propagated

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM python:3.11-slim-bullseye
 
+ADD https://github.com/krallin/tini/releases/download/v0.19.0/tini /tini
+RUN chmod +x /tini
+
 RUN apt-get update && apt-get install -y \
     socat \
     jq \
@@ -14,4 +17,4 @@ COPY bash-init.sh /bash-init.sh
 
 ENV BASH_ENV=/bash-init.sh
 
-ENTRYPOINT ["/bin/bash", "-l", "-c"]
+ENTRYPOINT ["/tini", "-g", "--", "/bin/bash", "-c"]

--- a/bash-init.sh
+++ b/bash-init.sh
@@ -2,6 +2,17 @@
 
 set -euo pipefail
 
+echoerr() { echo "$@" 1>&2; }
+
+echoerr "Porla is starting up..."
+echoerr "Executing: $BASH_EXECUTION_STRING"
+
+exit() {
+    echoerr "Porla is shutting down..."
+}
+
+trap exit SIGINT SIGTERM
+
 function to_bus () {
     bus="$1"
 


### PR DESCRIPTION
Using tini to fix the issue with bash not propagating SIGINT and SIGTERM properly. Specifically, the -g switch to tini makes it send the signal to the whole process group and not only to the direct subprocess.

closes #13 