### PR TITLE
Add websocat to porla base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,9 @@ FROM python:3.13-slim-bookworm
 ADD https://github.com/krallin/tini/releases/download/v0.19.0/tini /tini
 RUN chmod +x /tini
 
+ADD https://github.com/vi/websocat/releases/download/v1.14.1/websocat.x86_64-unknown-linux-musl /usr/local/bin/websocat
+RUN chmod +x /usr/local/bin/websocat
+
 RUN apt-get update && apt-get install -y \
     socat \
     jq \

--- a/README.md
+++ b/README.md
@@ -162,6 +162,10 @@ services:
 
   https://linux.die.net/man/1/parallel
 
+* **websocat**
+
+  https://github.com/vi/websocat
+
 ### Examples
 
 ```yaml


### PR DESCRIPTION
Download pre-built websocat binary from GitHub releases for WebSocket support in data pipelines.