### PR TITLE
Add Modbus support to Porla

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,16 @@ services:
 
   https://github.com/vi/websocat
 
+* **modbus**
+
+  Command-line tool for reading and writing Modbus registers over TCP or RTU (serial). Supports encoding/decoding of types larger than 16 bits (floats, 32-bit integers, etc.).
+
+  https://github.com/favalex/modbus-cli
+
+  Read example: `modbus -s 1 192.168.1.100:502 h@0/f` (read holding register 0 as float)
+
+  Write example: `modbus -s 1 192.168.1.100:502 h@0=42` (write value 42 to holding register 0)
+
 ### Examples
 
 ```yaml

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 parse==1.20.2
 mqtt-cli==0.4.2
 zenoh-cli==0.6.8
+modbus-cli==0.1.10


### PR DESCRIPTION
Add modbus-cli Python package to enable reading and writing Modbus registers over TCP or RTU (serial). Supports encoding/decoding of types larger than 16 bits (floats, 32-bit integers, etc.).